### PR TITLE
Minor fixes for OSX compatibility, removal of compilation warnings for CLang

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,7 +30,10 @@ LINK_LIBRARIES( ${POSTGRES_LIBRARY} ${FUSE_LDFLAGS} )
 INCLUDE_DIRECTORIES( ${POSTGRES_INCLUDE_DIR} ${FUSE_INCLUDE_DIRS} )
 
 
-set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FUSE_CFLAGS_OTHER} ${POSTGRES_CFLAGS}" )
+# FUSE_CFLAGS_OTHER may contain more then one option so we replace
+# the bad joining semicolons
+string(REPLACE ";" " " FUSE_CFLAGS_OTHER_SPLIT ${FUSE_CFLAGS_OTHER})
+set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FUSE_CFLAGS_OTHER_SPLIT} ${POSTGRES_CFLAGS}" )
 
 ADD_EXECUTABLE(  tableaufs
                  tableaufs.c workgroup.c workgroup.h

--- a/src/tableaufs.h
+++ b/src/tableaufs.h
@@ -1,0 +1,38 @@
+/*
+   Copyright (c) 2015, Tamas Foldi, Starschema
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+   1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+   2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+   THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+   IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+   OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+   IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+   NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   */
+#pragma once
+
+#include "tableaufs_version.h"
+
+/** A structure with the Postgres connection parameters */
+struct tableau_cmdargs {
+  char *pghost;
+  char *pgport;
+  char *pguser;
+  char *pgpass;
+};
+
+
+/** Get the connection parameters for the current session */
+struct tableau_cmdargs tableaufs_get_cmdargs();
+

--- a/src/tableaufs_version.h
+++ b/src/tableaufs_version.h
@@ -1,0 +1,35 @@
+/*
+   Copyright (c) 2015, Tamas Foldi, Starschema
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+   1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+   2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+   THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+   IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+   OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+   IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+   NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+   DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+   THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+   (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+   THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+   */
+#pragma once
+
+
+/* Versioning
+ * ----------
+ *
+ *  see http://semver.org/ for more details. 
+ */
+#define TABLEAUFS_VERSION_MAJOR "0"
+#define TABLEAUFS_VERSION_MINOR "7"
+#define TABLEAUFS_VERSION_PATCH "1"
+
+#define TABLEAUFS_VERSION TABLEAUFS_VERSION_MAJOR  "."  TABLEAUFS_VERSION_MINOR "."  TABLEAUFS_VERSION_PATCH

--- a/src/workgroup.h
+++ b/src/workgroup.h
@@ -26,8 +26,9 @@
 #include <stdint.h>
 #include <limits.h>
 #include <fcntl.h>
+#include <sys/stat.h>
 
-typedef enum 
+typedef enum
 {
   TFS_WG_READ = 0,
   TFS_WG_WRITE = 1,
@@ -58,13 +59,13 @@ typedef enum {
   TFS_WG_QUERY_SIZE = 3
 } tfs_wg_list_query_cols_t;
 
-typedef int(* tfs_wg_add_dir_t )(void *buf, const char *name, 
+typedef int(* tfs_wg_add_dir_t )(void *buf, const char *name,
     const struct stat *stbuf, off_t off);
 
-extern int TFS_WG_IO_operation(tfs_wg_operations_t op, const uint64_t loid, 
+extern int TFS_WG_IO_operation(tfs_wg_operations_t op, const uint64_t loid,
     const char * src, char * dst, const size_t size, const off_t offset);
 
-extern int TFS_WG_modife(const uint64_t fd, char * buf, const size_t size, 
+extern int TFS_WG_modife(const uint64_t fd, char * buf, const size_t size,
     const off_t offset, tfs_wg_operations_t op);
 
 extern int TFS_WG_open(const tfs_wg_node_t * node, int mode, uint64_t * fh);


### PR DESCRIPTION
- fixed fuse_opts to contain a null at the end
- fixed some printf format warnings (off_t)
- fixed some conversion warnings
- fixed some uninitialized variables warnings in if-else branches
- removed trailing whitespace
