### PR TITLE
Ubuntu minor fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2012, Tamas Foldi, Starschema
+# Copyright (c) 2012-2015, Tamas Foldi, Starschema
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -21,20 +21,31 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
-PROJECT(fuse-tableaufs C)
-#ENABLE_TESTING()
+cmake_minimum_required(VERSION 2.6)
+project(fuse-tableaufs C)
 
-# SET(CMAKE_VERBOSE_MAKEFILE ON)
-SET(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
-INCLUDE(DefaultCompilerFlags)
-INCLUDE(FindPkgConfig)
 
-FIND_PACKAGE(Postgres) 
-pkg_check_modules( FUSE REQUIRED fuse)
+set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+include(DefaultCompilerFlags)
+include(FindPkgConfig)
 
-SUBDIRS(
-         src
-       )
+# Try to find Postgres
+find_package(Postgres 9.0 REQUIRED)
 
-# -- EOF --
+# Load FUSE
+pkg_check_modules( FUSE REQUIRED fuse>=2.9.0)
+
+# Add the include directories
+include_directories(
+  ${POSTGRES_INCLUDE_DIR}
+  ${FUSE_INCLUDE_DIRS} )
+
+
+# SUBDIRS(...) is deprecated
+#
+# ADD_SUBDIRECTORY processes the subdir at the time it is called,
+# whereas SUBDIRS pushes the dirs onto a list which is processed
+# at the end of the current cmakelists file - this is the old
+# behaviour and some vars are initialized 'out of order'  -or at
+# least in unexpected order
+add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2012, Tamas Foldi, Starschema ltd
+# Copyright (c) 2012-2015, Tamas Foldi, Starschema
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -21,25 +21,29 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-# SET(CMAKE_VERBOSE_MAKEFILE ON)
-
-# -- src --
-
-LINK_LIBRARIES( ${POSTGRES_LIBRARY} ${FUSE_LDFLAGS} )
-
-INCLUDE_DIRECTORIES( ${POSTGRES_INCLUDE_DIR} ${FUSE_INCLUDE_DIRS} )
-
 
 # FUSE_CFLAGS_OTHER may contain more then one option so we replace
 # the bad joining semicolons
 string(REPLACE ";" " " FUSE_CFLAGS_OTHER_SPLIT ${FUSE_CFLAGS_OTHER})
-set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FUSE_CFLAGS_OTHER_SPLIT} ${POSTGRES_CFLAGS}" )
+message(">> Setting FUSE_CFLAGS_OTHER to ${FUSE_CFLAGS_OTHER_SPLIT}")
+set( TFS_COMPILE_FLAGS  "${FUSE_CFLAGS_OTHER_SPLIT} ${POSTGRES_CFLAGS}")
 
-ADD_EXECUTABLE(  tableaufs
-                 tableaufs.c workgroup.c workgroup.h
-                 )
+# Add the executable
+add_executable( tableaufs
+  tableaufs.c
+  workgroup.c
+  )
 
-INSTALL(
+# Set the compile flags on a pre-target basis
+set_target_properties(tableaufs PROPERTIES COMPILE_FLAGS ${TFS_COMPILE_FLAGS})
+
+# Link it with all the good stuff
+target_link_libraries( tableaufs
+  ${POSTGRES_LIBRARY}
+  ${FUSE_LDFLAGS}
+  )
+
+install(
   TARGETS tableaufs
   RUNTIME
   DESTINATION bin )
@@ -58,6 +62,4 @@ if(APPLE)
     COMMAND ln -sf ${TFS_EXEC_INSTALL_PATH} ${TFS_MOUNT_EXEC_INSTALL_PATH}
     )
   ")
-elseif(UNIX)
-  # Nada
 endif()

--- a/src/tableaufs.h
+++ b/src/tableaufs.h
@@ -26,10 +26,10 @@
 
 /** A structure with the Postgres connection parameters */
 struct tableau_cmdargs {
-  char *pghost;
-  char *pgport;
-  char *pguser;
-  char *pgpass;
+  const char *pghost;
+  const char *pgport;
+  const char *pguser;
+  const char *pgpass;
 };
 
 

--- a/src/workgroup.c
+++ b/src/workgroup.c
@@ -134,6 +134,7 @@ static PGconn* get_pg_connection()
     case CONNECTION_AWAITING_RESPONSE:
     case CONNECTION_STARTED:
     case CONNECTION_OK:
+    default:
       return global_conn;
   }
 }
@@ -392,7 +393,8 @@ int TFS_WG_connect_db(const char * pghost, const char * pgport,
     const char * login, const char * pwd)
 {
   // save the connection data to the global (eeeeek) state.
-  struct tableau_cmdargs conn_data = {(char*)pghost, (char*)pgport, (char*)login, (char*)pwd};
+  struct tableau_cmdargs conn_data = {pghost, pgport, login, pwd};
+  /*struct tableau_cmdargs conn_data = {(char*)pghost, (char*)pgport, (char*)login, (char*)pwd};*/
   pg_connection_data = conn_data;
 
   // Set up the connection


### PR DESCRIPTION
- minor fixes using Ubuntu GCC:
  - for const char\* -> char\* casts (only GCC complained)
  - added a  "default" branch for a switch where GCC is too dumb to figure out that all enum values are handled.
- modified the CMakeLists.txt:
  - apply switches and linkage on a per-target basis instead of globally
  - use lowercase commands for consistency
  - use add_subdirectory instead of subdirs
  - added version requirements for modules
